### PR TITLE
Use standalone prop-types 

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   "dependencies": {
     "classnames": "2.2.5",
     "object-assign": "^4.1.1",
+    "prop-types": "^15.5.8",
     "scrollfeatures": "^1.8.4"
   }
 }

--- a/src/react-sticky-state.js
+++ b/src/react-sticky-state.js
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from 'react';
+import PropTypes from 'PropTypes';
 import classNames from 'classnames';
 import ScrollFeatures from 'scrollfeatures';
 import assign from 'object-assign';

--- a/src/react-sticky-state.js
+++ b/src/react-sticky-state.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react';
-import PropTypes from 'PropTypes';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import ScrollFeatures from 'scrollfeatures';
 import assign from 'object-assign';


### PR DESCRIPTION
fix for Warning:
Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.